### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,15 +29,15 @@ This user-friendly module boasts of an easy integration process that enables sea
 1. Add nuxt-chatgpt dependency to your project
 * npm
   ```sh
-  npm install --save-dev nuxt-chatgpt
+  npx nuxi@latest module add nuxt-chatgpt
   ```
 * pnpm
   ```sh
-  pnpm add -D nuxt-chatgpt
+  npx nuxi@latest module add nuxt-chatgpt
   ```
 * yarn
   ```sh
-  yarn add --dev nuxt-chatgpt
+  npx nuxi@latest module add nuxt-chatgpt
   ```
 2. Add nuxt-chatgpt to the modules section of nuxt.config.ts
 


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
